### PR TITLE
Using /connectors as main subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,29 @@ First build jekyll `bundle exec jekyll build` then build the stylesheet `yarn ru
 
 ## Development
 Run `./bin/dev` to start jekyll and tailwind processes.
+
+## Notes
+
+### baseurl
+
+`baseurl` configuration is used to set the /connectors subpath as the main path for the website.
+
+All relative URLs must be built as `{{ site.baseuri }}/path`.
+
+This is because the reverse proxy is configured to send all `/connectors/*` requests to this website.
+
+### permalink
+
+All connector pages must set the permalink attribute in their frontmatter.
+
+```markdown
+---
+title: "LinkedIn Connector"
+permalink: linkedin
+...
+---
+```
+
+The permalink is used as the final destination of the page. For instance, for the example above the final destination will be: `/connectors/linkedin`.
+
+`/connectors` is prepended automatically because of the `baseurl`.

--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ email: jesse.ocon@growthnirvana.com
 description: >- # this means to ignore newlines until "baseurl:"
   Stop waiting for other departments to get the data you need to make critical business decisions.
   Take control of the insights that will grow your business.
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/connectors" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: ""
 github_username: ""

--- a/_connectors/linkedin.md
+++ b/_connectors/linkedin.md
@@ -1,5 +1,6 @@
 ---
 layout: connector
+permalink: linkedin
 title:  "LinkedIn Connector"
 date:   2023-08-04 12:33:59 -0300
 categories: connectors
@@ -12,7 +13,7 @@ sections:
       Create in-depth user engagement report on your posts, comments,
       and company updates on your LinkedIn channels. Generate reports
       to measure LinkedIn ads performance.
-    image_url: /assets/images/linkedin-overview.webp
+    image_url: /connectors/assets/images/linkedin-overview.webp
 
   body:
     title: >-
@@ -21,7 +22,5 @@ sections:
     description: >-
       Track number of followers, follower industry, page views, leads,
       cost per lead (CPL), and much, much more.
-    image_url: /assets/images/linkedin-body.webp
-
-
+    image_url: /connectors/assets/images/linkedin-body.webp
 ---


### PR DESCRIPTION
Updated the config.yml to set a baseurl.
This is required to make the reverse proxy easily send all /connectors/* requests to the seo pages website.

Updated the linkedin page to set a permalink.

Updated the readme.