### PR TITLE
Added a calendly link html

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,1 @@
-css: yarn run dev
 web: bundle exec jekyll serve --open-url --host=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 First build jekyll `bundle exec jekyll build` then build the stylesheet `yarn run build`.
 
 ## Development
-Run `./bin/dev` to start jekyll and tailwind processes.
+Run `./bin/dev` to start jekyll.
 
 ## How to download connector icons
 

--- a/_config.yml
+++ b/_config.yml
@@ -67,3 +67,4 @@ exclude:
   - .env.sample
   - .env
   - generator/
+  - main.css

--- a/_data/calendly.yml
+++ b/_data/calendly.yml
@@ -1,0 +1,3 @@
+user_name: ajayvaria
+event_link: 15min
+text: "Start Your 30-day Free Trial"

--- a/_includes/calendly_link.html
+++ b/_includes/calendly_link.html
@@ -1,0 +1,16 @@
+<a href="" onclick="var urlParams = new URLSearchParams(window.location.search);
+  Calendly.initPopupWidget(
+    {
+      url: 'https://calendly.com/{{ site.data.calendly.user_name }}/{{ site.data.calendly.event_link }}',
+      utm: {
+        utmCampaign: urlParams.get('utm_campaign') || urlParams.get('campaignid') || 'None',
+        utmSource: urlParams.get('utm_source') || 'google',
+        utmMedium: urlParams.get('utm_medium') || 'cpc',
+        utmTerm: urlParams.get('utm_term') || urlParams.get('keyword') || 'None',
+        utmContent: '{{ include.utm_content }}'
+      }
+    }
+  );return false;"
+  class="{{ include.class }}">
+    {{ include.text | default: site.data.calendly.text }}
+</a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,4 +36,6 @@
   <link rel="sitemap" type="application/xml" title="sitemap" href="{{ site.baseurl }}/sitemap.xml" />
   <script type="text/javascript" src="{{ site.baseurl }}/assets/seo_pages/main.js"></script>
 
+  <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">
+  <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,10 +26,10 @@
           </div>
         {% endfor %}
 
-        <a href="/schedule-demo" class="btn btn-primary text-base hidden lg:flex">Start Your 30-day Free Trial</a>
+        {% include calendly_link.html class="btn btn-primary text-base hidden lg:flex" utm_content=page.permalink %}
       </div>
     </div>
-  
+
     <div class="lg:hidden">
       <button type="button" class="lg:hidden inline-flex items-center justify-center pt-2.5 rounded-md text-gray-700" onclick="toggleMobileMenu()">
         <span class="sr-only">Open main menu</span>
@@ -73,7 +73,7 @@
                 {% endfor %}
               </div>
               <div class="py-6">
-                <a href="/schedule-demo" class="flex justify-center btn btn-primary text-base">Start Your 30-day Free Trial</a>
+                {% include calendly_link.html class="btn btn-primary flex justify-center text-base" utm_content=page.permalink %}
               </div>
             </div>
           </div>

--- a/_layouts/connector.html
+++ b/_layouts/connector.html
@@ -15,7 +15,7 @@ layout: default
         </p>
 
         <p class="mt-10 flex justify-center lg:justify-normal">
-          <a href="/schedule-demo" class="btn btn-primary">Start Your 30-day Free Trial</a>
+          {% include calendly_link.html class="btn btn-primary" utm_content=page.permalink %}
         </p>
       </div>
       <div class="flex flex-row justify-center">
@@ -41,9 +41,10 @@ layout: default
         </p>
 
         <p class="mt-10 flex justify-center lg:justify-normal">
-          <a href="/schedule-demo" class="btn-underline btn-underline-primary">
+          {% capture cta_html %}
             Book a Demo {% include icons/chevron-right.svg class="inline" %}
-          </a>
+          {% endcapture %}
+          {% include calendly_link.html class="btn-underline btn-underline-primary" utm_content=page.permalink text=cta_html %}
         </p>
       </div>
     </div>
@@ -91,7 +92,7 @@ layout: default
           {% endfor %}
         </div>
         <p class="mt-5 flex justify-center">
-          <a href="/schedule-demo" class="btn btn-primary">Book a demo</a>
+          {% include calendly_link.html class="btn btn-primary" utm_content=page.permalink %}
         </p>
       </div>
     </div>

--- a/_plugins/tailwind.rb
+++ b/_plugins/tailwind.rb
@@ -1,0 +1,3 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  system "yarn run build"
+end


### PR DESCRIPTION
Added a reusable html file to render the calendly link. It uses the embed code from Calendly.
Updated the <head> to included Calendly assets.

Added a tailwind plugin that registers a hook to regenerate the css after files are written by Jekyll.